### PR TITLE
fix(doc): correct example env file name in cp command

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -37,7 +37,7 @@ docker compose up -d
 Copy env variables from the example:
 
 ```bash
-cp .example.env .env
+cp .env.example .env
 ```
 
 Be sure to populate database urls; at this stage, they are the most important thing to get started locally:


### PR DESCRIPTION
The file `.example.env` does not exist in the project, so this commit corrects the filename to `.env.example`.